### PR TITLE
Fixed compilation with GHC 8.6.1.

### DIFF
--- a/Test/Tasty/Silver/Interactive.hs
+++ b/Test/Tasty/Silver/Interactive.hs
@@ -33,7 +33,7 @@ import Test.Tasty.Silver.Interactive.Run
 import Data.Typeable
 import Data.Tagged
 import Data.Maybe
-import Data.Monoid hiding ((<>))
+import Data.Monoid ( Any(..) )
 import Data.Semigroup (Semigroup(..))
 import qualified Data.Text.IO as TIO
 import Data.Char


### PR DESCRIPTION
GHC 8.6.1 was [released](https://mail.haskell.org/pipermail/glasgow-haskell-users/2018-September/026803.html). Using this version of GHC I get various errors like:

```haskell
$ cabal install
[6 of 6] Compiling Test.Tasty.Silver.Interactive ( Test/Tasty/Silver/Interactive.hs, dist/build/Test/Tasty/Silver/Interactive.o )

Test/Tasty/Silver/Interactive.hs:309:40: error:
    Ambiguous occurrence ‘Ap’
    It could refer to either ‘Test.Tasty.Runners.Ap’,
                             imported from ‘Test.Tasty.Runners’ at Test/Tasty/Silver/Interactive.hs:28:1-25
                             (and originally defined in ‘tasty-1.1.0.3:Test.Tasty.Runners.Reducers’)
                          or ‘Data.Monoid.Ap’,
                             imported from ‘Data.Monoid’ at Test/Tasty/Silver/Interactive.hs:36:1-32
    |
309 |       => OptionSet -> TestName -> t -> Ap (Reader Level) TestOutput
    |                                        ^^

Test/Tasty/Silver/Interactive.hs:310:41: error:
    Ambiguous occurrence ‘Ap’
    It could refer to either ‘Test.Tasty.Runners.Ap’,
                             imported from ‘Test.Tasty.Runners’ at Test/Tasty/Silver/Interactive.hs:28:1-25
                             (and originally defined in ‘tasty-1.1.0.3:Test.Tasty.Runners.Reducers’)
                          or ‘Data.Monoid.Ap’,
                             imported from ‘Data.Monoid’ at Test/Tasty/Silver/Interactive.hs:36:1-32
    |
310 |     handleSingleTest _opts name _test = Ap $ do
    |                                         ^^
```

This PR fix these errors.

Blocking https://github.com/agda/agda/issues/3160.

