### PR TITLE
Always use `git diff` with `diff` style exit codes

### DIFF
--- a/Test/Tasty/Silver/Interactive.hs
+++ b/Test/Tasty/Silver/Interactive.hs
@@ -185,8 +185,9 @@ printDiff n (DiffText _ tGold tAct) = do
       (\fGold fAct -> do
         ret <- PTL.readProcessWithExitCode "sh" ["-c", "git diff --no-index --text --exit-code" ++ fGold ++ " " ++ fAct] T.empty
         case ret of
-         ret@(ExitFailure 2, _, _) -> error ("Call to `git diff` failed: " ++ show ret)
-         (_, stdOut, _) -> TIO.putStrLn stdOut
+         (ExitSuccess, stdOut, _)   -> TIO.putStrLn stdOut
+         (ExitFailure 1, stdOut, _) -> TIO.putStrLn stdOut
+         ret@(ExitFailure _, _, _)  -> error ("Call to `git diff` failed: " ++ show ret)
       )
   else do
     putStrLn "`git diff` not available, cannot produce a diff."

--- a/Test/Tasty/Silver/Interactive.hs
+++ b/Test/Tasty/Silver/Interactive.hs
@@ -183,10 +183,10 @@ printDiff n (DiffText _ tGold tAct) = do
   if hasGit then
     withDiffEnv n tGold tAct
       (\fGold fAct -> do
-        ret <- PTL.readProcessWithExitCode "sh" ["-c", "git diff --no-index --text " ++ fGold ++ " " ++ fAct] T.empty
+        ret <- PTL.readProcessWithExitCode "sh" ["-c", "git diff --no-index --text --exit-code" ++ fGold ++ " " ++ fAct] T.empty
         case ret of
-          (ExitSuccess, stdOut, _) -> TIO.putStrLn stdOut
-          _ -> error ("Call to `git diff` failed: " ++ show ret)
+         ret@(ExitFailure 2, _, _) -> error ("Call to `git diff` failed: " ++ show ret)
+         (_, stdOut, _) -> TIO.putStrLn stdOut
       )
   else do
     putStrLn "`git diff` not available, cannot produce a diff."


### PR DESCRIPTION
Proposed fix to #20 

Call git diff with `--exit-code` every time, instead of relying on defaults.
This results in the program returning `2` if an error occurred (`0` and `1` for successful runs)