### PR TITLE
Require cabal-version 1.14

### DIFF
--- a/tasty-silver.cabal
+++ b/tasty-silver.cabal
@@ -22,7 +22,7 @@ maintainer:          Philipp Hausmann
 -- copyright:           
 category:            Testing
 build-type:          Simple
-cabal-version:       >=1.14
+cabal-version:       1.14
 extra-source-files:  CHANGELOG.md
 tested-with:         GHC == 8.0.1, GHC == 8.2.2, GHC == 8.6.1
 


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: tasty-silver.cabal:25:28: Packages with 'cabal-version: 1.12' or                                                                
later should specify a specific version of the Cabal spec of the form        
'cabal-version: x.y'. Use 'cabal-version: 1.14'.  
```