### PR TITLE
Fix #29: capture stdout of test that runs tryIngredients

### DIFF
--- a/tasty-silver.cabal
+++ b/tasty-silver.cabal
@@ -101,3 +101,9 @@ Test-suite test
     , process
     , temporary
     , transformers >= 0.3
+
+  if impl(ghc >= 8.0)
+    ghc-options:
+      -Wall
+      -Wno-name-shadowing
+      -Wcompat

--- a/tasty-silver.cabal
+++ b/tasty-silver.cabal
@@ -99,6 +99,8 @@ Test-suite test
     , filepath
     , directory
     , process
+    , silently >= 1.2.5.1
+        -- Andreas Abel, 2021-09-05, latest silently is today 1.2.5.1
     , temporary
     , transformers >= 0.3
 

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -1,24 +1,27 @@
 {-# LANGUAGE CPP #-}
 
-import Test.Tasty hiding (defaultMain)
-import Test.Tasty.HUnit
-import Test.Tasty.Silver
-import Test.Tasty.Silver.Interactive
-import Test.Tasty.Runners
-import Test.Tasty.Silver.Advanced
-import Test.Tasty.Silver.Internal
-import Test.Tasty.Options
-import Test.Tasty.Silver.Filter (checkRF)
-
+import Control.Concurrent.MVar
+import Control.Monad (unless)
+import Control.Monad.IO.Class (liftIO)
+import Data.List (sort)
 #if !(MIN_VERSION_base(4,8,0))
 import Data.Monoid (mempty)
 #endif
-import System.IO.Temp
-import System.FilePath
+
 import System.Directory
-import Data.List (sort)
-import Control.Concurrent.MVar
-import Control.Monad.IO.Class (liftIO)
+import System.FilePath
+import System.IO.Silently (capture)
+import System.IO.Temp
+
+import Test.Tasty hiding (defaultMain)
+import Test.Tasty.HUnit
+import Test.Tasty.Options
+import Test.Tasty.Runners
+import Test.Tasty.Silver
+import Test.Tasty.Silver.Advanced
+import Test.Tasty.Silver.Filter (checkRF)
+import Test.Tasty.Silver.Interactive
+import Test.Tasty.Silver.Internal
 
 touch :: FilePath -> IO ()
 touch f = writeFile f ""
@@ -61,7 +64,8 @@ testWithResource =
   testCase "withResource" $
     case tryIngredients [consoleTestReporter] (singleOption $ AcceptTests True) tree of
       Just r' -> do
-        success <- r'
+        (out, success) <- capture r'
+        unless success $ putStr out
         assertBool "Test should succeed." success
       Nothing -> assertFailure "Test broken"
   where

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 import Test.Tasty hiding (defaultMain)
 import Test.Tasty.HUnit
 import Test.Tasty.Silver
@@ -6,64 +8,85 @@ import Test.Tasty.Runners
 import Test.Tasty.Silver.Advanced
 import Test.Tasty.Silver.Internal
 import Test.Tasty.Options
-import Test.Tasty.Silver.Filter
+import Test.Tasty.Silver.Filter (checkRF)
 
-import Data.Monoid
+#if !(MIN_VERSION_base(4,8,0))
+import Data.Monoid (mempty)
+#endif
 import System.IO.Temp
 import System.FilePath
 import System.Directory
 import Data.List (sort)
 import Control.Concurrent.MVar
-import Control.Monad.IO.Class
+import Control.Monad.IO.Class (liftIO)
 
+touch :: FilePath -> IO ()
 touch f = writeFile f ""
 
-main = defaultMain $ testGroup "tests" [testFindByExt, testWithResource, testCheckRF]
-
-
+main :: IO ()
+main = defaultMain $ testGroup "tests" $
+  testFindByExt :
+  testWithResource :
+  testCheckRF :
+  []
 
 testFindByExt :: TestTree
-testFindByExt = testCase "findByExtension" $
+testFindByExt =
+  testCase "findByExtension" $
     withSystemTempDirectory "golden-test" $ \basedir -> do
 
       setCurrentDirectory basedir
 
       createDirectory ("d1")
       createDirectory ("d1" </> "d2")
-      touch ("f1.c")
-      touch ("f2.h")
-      touch ("f2.exe")
-      touch ("d1" </> "g1.c")
-      touch ("d1" </> "d2" </> "h1.c")
+      touch ("d1" </> "d2" </> "h1.c")      -- match
       touch ("d1" </> "d2" </> "h1.exe")
       touch ("d1" </> "d2" </> "h1")
+      touch ("d1" </> "g1.c")               -- match
+      touch ("f1.c")                        -- match
+      touch ("f2.h")                        -- match
+      touch ("f2.exe")
 
       files <- findByExtension [".c", ".h"] "."
       sort files @?= sort
-        ["./d1/d2/h1.c","./d1/g1.c","./f1.c","./f2.h"]
+        [ "./d1/d2/h1.c"
+        , "./d1/g1.c"
+        , "./f1.c"
+        , "./f2.h"
+        ]
 
+-- | Check if resources are properly initialized.
 testWithResource :: TestTree
-testWithResource = testCase "withResource" $ do
-    -- check if resources are properly initialized
-    testRes <- newMVar False
-    let acq = newMVar True
-        free v = swapMVar v False >> return ()
-        test = \v -> goldenTest1 "check res" (return Nothing) (liftIO $ testAction v) (\_ _ -> Equal) (\_ -> ShowText mempty) upd
-        upd x = assertBool "Incorrect result" x >> return ()
-        testAction = \v -> v >>= readMVar >>= assertBool "Resource not initialized." >> return True
-        tree = withResource acq free test
-
-    let r = tryIngredients [consoleTestReporter] (singleOption $ AcceptTests True) tree
-    case r of
+testWithResource =
+  testCase "withResource" $
+    case tryIngredients [consoleTestReporter] (singleOption $ AcceptTests True) tree of
       Just r' -> do
         success <- r'
         assertBool "Test should succeed." success
       Nothing -> assertFailure "Test broken"
+  where
+    tree   = withResource acq free test
+    -- Resource acquisition.
+    acq    = newMVar True
+    -- Resource release.
+    free v = swapMVar v False >> return ()
+    -- Test using resource.
+    test v = goldenTest1 "check res"
+               (return Nothing)           -- get the golden value
+               (liftIO $ testAction v)    -- get the tested value
+               (\ _ _ -> Equal)           -- comparison function (always succeed)
+               (\ _   -> ShowText mempty) -- show the golden/actual value
+               (\ x   -> assertBool "Incorrect result" x)  -- update the golden file
+    -- Actual test: check whether the MVar contains True.
+    testAction v = do
+      assertBool "Resource not initialized." =<< readMVar =<< v
+      return True
 
 testCheckRF :: TestTree
-testCheckRF = testGroup "Filter.checkRF"
-    [ testCase "empty1a" $ checkRF True [] "/" @?= True
-    , testCase "empty1b" $ checkRF False [] "/" @?= False
-    , testCase "empty2a" $ checkRF True [] "/sdfg" @?= True
+testCheckRF =
+  testGroup "Filter.checkRF"
+    [ testCase "empty1a" $ checkRF True  [] "/"     @?= True
+    , testCase "empty1b" $ checkRF False [] "/"     @?= False
+    , testCase "empty2a" $ checkRF True  [] "/sdfg" @?= True
     , testCase "empty2b" $ checkRF False [] "/sdfg" @?= False
     ]


### PR DESCRIPTION
Fix #29: capture `stdout` of test that runs `tryIngredients`.
This prevents garbled output.