### PR TITLE
Windows portability (fix #16)

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20210606
+# version: 0.13.20210901
 #
-# REGENDATA ("0.13.20210606",["github","tasty-silver.cabal"])
+# REGENDATA ("0.13.20210901",["github","tasty-silver.cabal"])
 #
 name: Haskell-CI
 on:
@@ -26,15 +26,20 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.2.0.20210821
+            compilerKind: ghc
+            compilerVersion: 9.2.0.20210821
+            setup-method: ghcup
+            allow-failure: true
           - compiler: ghc-9.0.1
             compilerKind: ghc
             compilerVersion: 9.0.1
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-8.10.4
+          - compiler: ghc-8.10.7
             compilerKind: ghc
-            compilerVersion: 8.10.4
-            setup-method: hvr-ppa
+            compilerVersion: 8.10.7
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.4
             compilerKind: ghc
@@ -87,9 +92,17 @@ jobs:
         run: |
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
-          apt-add-repository -y 'ppa:hvr/ghc'
-          apt-get update
-          apt-get install -y "$HCNAME" cabal-install-3.4
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.16.2/x86_64-linux-ghcup-0.1.16.2 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.4.0.0
+          else
+            apt-add-repository -y 'ppa:hvr/ghc'
+            apt-get update
+            apt-get install -y "$HCNAME" cabal-install-3.4
+          fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -101,16 +114,25 @@ jobs:
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
-          HC=$HCDIR/bin/$HCKIND
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-          echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> "$GITHUB_ENV"
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.4.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          else
+            HC=$HCDIR/bin/$HCKIND
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
+            echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> "$GITHUB_ENV"
+          fi
+
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 90200)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -139,6 +161,17 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          EOF
+          fi
           cat $CABAL_CONFIG
       - name: versions
         run: |
@@ -186,6 +219,9 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(bytestring|directory|process|tasty-silver)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -211,7 +247,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
         run: |
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options=-i
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
       - name: cabal check
         run: |
           cd ${PKGDIR_tasty_silver} || false

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -211,7 +211,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
         run: |
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options=-i
       - name: cabal check
         run: |
           cd ${PKGDIR_tasty_silver} || false

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -186,7 +186,7 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(bytestring|process|tasty-silver)$/; }' >> cabal.project.local
+          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(bytestring|directory|process|tasty-silver)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Configure the build plan
       run: |
         cabal update
-        cabal configure -O1 --enable-tests
+        cabal configure -O1 --enable-tests --test-show-details=direct
 
     - uses: actions/cache@v2
       name: Cache dependencies
@@ -64,4 +64,4 @@ jobs:
 
     - name: Test
       run: |
-        cabal test
+        cabal test --test-show-details=direct

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Configure the build plan
       run: |
         cabal update
-        cabal configure -O1 --enable-tests --test-show-details=direct
+        cabal configure -O1 --enable-tests
 
     - uses: actions/cache@v2
       name: Cache dependencies
@@ -64,4 +64,4 @@ jobs:
 
     - name: Test
       run: |
-        cabal test --test-show-details=direct
+        cabal test --test-show-details=direct --test-options=-i

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Configure the build plan
       run: |
         cabal update
-        cabal configure -O1 --enable-tests
+        cabal configure -O1 --enable-tests --test-show-details=direct
 
     - uses: actions/cache@v2
       name: Cache dependencies
@@ -64,4 +64,4 @@ jobs:
 
     - name: Test
       run: |
-        cabal test
+        cabal test --test-show-details=direct

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Configure the build plan
       run: |
         cabal update
-        cabal configure -O1 --enable-tests --test-show-details=direct
+        cabal configure -O1 --enable-tests
 
     - uses: actions/cache@v2
       name: Cache dependencies
@@ -64,4 +64,4 @@ jobs:
 
     - name: Test
       run: |
-        cabal test --test-show-details=direct
+        cabal test --test-show-details=direct --test-options=-i

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changes
 =======
 
+Version 3.3 (unreleased)
+------------------------
+
+* Windows portability (#16):
+  - Calls to `git diff` are no longer indirected via `sh -c`.
+  - When indirection via `sh -c` is used, backslashes in filenames are converted to slashes.
+
+* Interactive (`-i`): If `stdin` is redirected (`hIsTerminalDevice stdin` gives `False`),
+  answer "yes" is assumed, so golden values are updated.
+
 Version 3.2.3 (13 Sep 2021)
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@ Version 3.3 (unreleased)
   - Calls to `git diff` are no longer indirected via `sh -c`.
   - When indirection via `sh -c` is used, backslashes in filenames are converted to slashes.
 
-* Interactive (`-i`): If `stdin` is redirected (`hIsTerminalDevice stdin` gives `False`),
-  answer "yes" is assumed, so golden values are updated.
-
 Version 3.2.3 (13 Sep 2021)
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 Changes
 =======
 
-Version 3.3 (unreleased)
-------------------------
+Version 3.3 (20 Sep 2021)
+-----------
 
 * Windows portability (#16):
   - Calls to `git diff` are no longer indirected via `sh -c`.
   - When indirection via `sh -c` is used, backslashes in filenames are converted to slashes.
+* Tested with GHC 7.4 - 9.2.1-RC1
 
 Version 3.2.3 (13 Sep 2021)
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,81 +7,81 @@ Version 3.2.3 (13 Sep 2021)
 * Tested with GHC 7.4 - 9.0 (fixed compilation with GHC 7.4 - 7.8)
 * CI via GitHub Actions on platforms `ubuntu`, `macOS`, `windows`.
 
-Version 3.2.2
+Version 3.2.2 (22 Jun 2021)
 -------------
 
 * Fix cabal warning (#27, thanks to felixonmars)
 
-Version 3.2.1
+Version 3.2.1 (22 Dec 2020)
 -------------
 
 * Fix option parser (#25)
 
-Version 3.2
+Version 3.2 (21 Dec 2020)
 -----------
 
 * Compatibility with tasty 1.4 (breaks compatibility with older versions of tasty)
 
-Version 3.1.15
+Version 3.1.15 (8 Jun 2020)
 --------------
 
 * Fix missing space in git diff calls introduced in v3.1.14 (#22, thanks to croyzor)
 
-Version 3.1.14
+Version 3.1.14 (8 Jun 2020)
 --------------
 
 * Fix wrong interpretation of git diff exit codes (#21, thanks to croyzor)
 
-Version 3.1.13
+Version 3.1.13 (12 Jul 2019)
 --------------
 
 * Add option to disable ansi tricks (#18, thanks to L-TChen)
 
-Version 3.1.12
+Version 3.1.12 (24 Sep 2018)
 --------------
 
 * Fix compilation with GHC 8.4 (thanks to asr)
 
-Version 3.1.11
+Version 3.1.11 (29 Dec 2017)
 --------------
 
 * Fix compilation with GHC 8.4
 
-Version 3.1.10
+Version 3.1.10 (1 Apr 2017)
 --------------
 
 * Better error handling for calls to external tools (`git diff`)
 
-Version 3.1.9
+Version 3.1.9 (29 Aug 2016)
 -------------
 
 * Fix compilation with optparse-applicative 0.13.*.
 * Provide character-level diff if wdiff and colordiff are available.
 
-Version 3.1.8.1
+Version 3.1.8.1 (19 Jan 2016)
 ---------------
 
 * Fix compilation with GHC 8.
 
-Version 3.1.8
+Version 3.1.8 (10 Nov 2015)
 -------------
 
 * Make update function optional for test cases.
 
-Version 3.1.7
+Version 3.1.7 (14 May 2015)
 -------------
 
 * Add feature to disable certain tests, still showing them in the UI
   but not running them.
 * Fix a concurrency issue in the interactive test runner.
 
-Version 3.1.6
+Version 3.1.6 (14 May 2015)
 -------------
 
 * Expose regex filter modules.
 * Fix issue with regex filters when used together with withResource nodes.
 
-Version 3.1.5
+Version 3.1.5 (12 Apr 2015)
 -------------
 
 * Add experimental --regex-include option to select tests using a regex.
@@ -89,30 +89,30 @@ Version 3.1.5
 * The --regex-include/--regex-exclude option may be given multiple times now.
   The exclusion regexes are applied first, after that all inclusion regexes.
 
-Version 3.1.4
+Version 3.1.4 (12 Apr 2015)
 -------------
 
 * Add experimental --regex-exclude option to filter out tests using a regex.
   This option is highly experimental and may change in later versions!
 
-Version 3.1.3
+Version 3.1.3 (6 Apr 2015)
 -------------
 
 * Use package temporary instead of temporary-rc.
 * Re-add command line options for test runner which were accidentally removed.
 
-Version 3.1.2
+Version 3.1.2 (6 Apr 2015)
 -------------
 
 * Add non-interactive mode to test runner, printing diffs/actual values directly to stdout.
   Useful for (travis) CI.
 
-Version 3.1.1
+Version 3.1.1 (4 Apr 2015)
 -------------
 
 * Report success instead of failure if new result is accepted in interactive mode.
 
-Version 3.1
+Version 3.1 (4 Apr 2015)
 -----------
 
 * Fixed & tested support for GHC 7.4.2 - 7.10.1
@@ -121,7 +121,7 @@ Version 3.1
 * Enable travis CI builds
 
 Version 3.0 - 3.0.2.2
------------
+---------------------
 
 * Refactored API
 * Add interactive mode

--- a/README.md
+++ b/README.md
@@ -23,6 +23,29 @@ to the user. Based upon this diff, the user can choose to update the golden stan
 fix the test case as necessary. Interactive mode requires that at least `git diff` and `less` is
 available, or preferrably `wdiff` and `colordiff` for character-based diffs.
 
+If `-i` is supplied but no user input can be received (`hIsTerminalDevice stdin` gives `False`),
+then answer "yes" is assumed on questions whether to update the golden value.
+(So, with `-i < /dev/null` one can update all golden values.)
+
+Portability
+-----------
+
+`tasty-silver` aims to work under Linux, macOS, and Windows.  In
+particular, it should work in the [GitHub CI virtual
+environments](https://github.com/actions/virtual-environments).
+
+Known limitations:
+
+- On `macOS`, GHC ≥ 7.10 is required, as GHC ≤ 7.8 produces code that
+  is not compatible with the System Integrity Protection mechanism of
+  Mac OS X.  In particular, you could see errors like:
+  ```
+  /usr/bin/less: getPermissions:fileAccess: permission denied (Operation not permitted)
+  ```
+
+- On Windows, the colored diff may not be available as it depends on
+  the availability of `colordiff`, `less`, `sh`, and `wdiff`.
+
 Examples
 --------
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@ to the user. Based upon this diff, the user can choose to update the golden stan
 fix the test case as necessary. Interactive mode requires that at least `git diff` and `less` is
 available, or preferrably `wdiff` and `colordiff` for character-based diffs.
 
-If `-i` is supplied but no user input can be received (`hIsTerminalDevice stdin` gives `False`),
-then answer "yes" is assumed on questions whether to update the golden value.
-(So, with `-i < /dev/null` one can update all golden values.)
-
 Portability
 -----------
 

--- a/Test/Tasty/Silver.hs
+++ b/Test/Tasty/Silver.hs
@@ -169,18 +169,15 @@ findByExtension
   :: [FilePath] -- ^ extensions
   -> FilePath -- ^ directory
   -> IO [FilePath] -- ^ paths
-findByExtension extsList = go where
+findByExtension extsList = go
+  where
   exts = Set.fromList extsList
   go dir = do
     allEntries <- getDirectoryContents dir
     let entries = filter (not . (`elem` [".", ".."])) allEntries
     liftM concat $ forM entries $ \e -> do
-      let path = dir ++ "/" ++ e
+      let path = dir ++ "/" ++ e         -- NOT </>! Slash accepted even on Windows.
       isDir <- doesDirectoryExist path
       if isDir
         then go path
-        else
-          return $
-            if takeExtension path `Set.member` exts
-              then [path]
-              else []
+        else return [ path | takeExtension path `Set.member` exts ]

--- a/Test/Tasty/Silver/Advanced.hs
+++ b/Test/Tasty/Silver/Advanced.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE CPP #-}
 
 module Test.Tasty.Silver.Advanced
-  ( -- * The main function
+  ( -- * Constructing golden tests
     goldenTest1,
 
     goldenTestIO,
@@ -12,7 +12,7 @@ module Test.Tasty.Silver.Advanced
     GShow (..),
     GDiff (..),
 
-    -- * reading files
+    -- * Reading files
     readFileMaybe
   )
 where

--- a/Test/Tasty/Silver/Filter.hs
+++ b/Test/Tasty/Silver/Filter.hs
@@ -38,6 +38,7 @@ import Test.Tasty hiding (defaultMain)
 import Test.Tasty.Options
 import Test.Tasty.Runners
 
+-- | Path into the 'TestTree'.  Separator is the slash character(@'/'@).
 type TestPath = String
 
 -- we have to store the regex as String, as there is no Typeable instance
@@ -97,9 +98,10 @@ filterWithRegex opts = filterWithPred (checkRF True $ excRgxs ++ incRgxs)
 -- are met:
 -- 1. At least one RFInclude matches.
 -- 2. No RFExclude filter matches.
-checkRF :: Bool -- ^ If true, ignore 1. condition if no RFInclude is given.
+checkRF :: Bool -- ^ If 'True', ignore first condition if no 'RFInclude' is given.
     -> [RegexFilter]
-    -> TestPath -> Bool
+    -> TestPath
+    -> Bool
 checkRF ignNoInc rf tp =
   ((null incRgxs && ignNoInc) || any regexMatches incRgxs)
     && (not $ any regexMatches excRgxs)

--- a/Test/Tasty/Silver/Interactive.hs
+++ b/Test/Tasty/Silver/Interactive.hs
@@ -300,13 +300,13 @@ tryAccept
   -> IO ()    -- ^ Action to @update@ golden value.
   -> IO Bool  -- ^ Return decision whether to update the golden value.
 tryAccept prefix update = do
-  isTerm <- hSupportsANSI stdout
-  when isTerm showCursor
+  isANSI <- hSupportsANSI stdout
+  when isANSI showCursor
   putStr prefix
   putStr "Accept actual value as new golden value? [yn] "
   let
     done b = do
-      when isTerm hideCursor
+      when isANSI hideCursor
       putStr prefix
       return b
     loop = do
@@ -678,11 +678,12 @@ instance Monoid FailureStatus where
 -- | Report only failed tests
 newtype HideSuccesses = HideSuccesses Bool
   deriving (Eq, Ord, Typeable)
+
 instance IsOption HideSuccesses where
-  defaultValue = HideSuccesses False
-  parseValue = fmap HideSuccesses . safeRead
-  optionName = return "hide-successes"
-  optionHelp = return "Do not print tests that passed successfully"
+  defaultValue   = HideSuccesses False
+  parseValue     = fmap HideSuccesses . safeRead
+  optionName     = return "hide-successes"
+  optionHelp     = return "Do not print tests that passed successfully"
   optionCLParser = flagCLParser Nothing (HideSuccesses True)
 
 newtype AnsiTricks = AnsiTricks Bool
@@ -690,9 +691,9 @@ newtype AnsiTricks = AnsiTricks Bool
 
 instance IsOption AnsiTricks where
   defaultValue = AnsiTricks True
-  parseValue = fmap AnsiTricks . safeReadBool
-  optionName = return "ansi-tricks"
-  optionHelp = return $
+  parseValue   = fmap AnsiTricks . safeReadBool
+  optionName   = return "ansi-tricks"
+  optionHelp   = return $
     -- Multiline literals don't work because of -XCPP.
     "Enable various ANSI terminal tricks. " ++
     "Can be set to 'true' (default) or 'false'."
@@ -704,10 +705,10 @@ data UseColor
 
 -- | Control color output
 instance IsOption UseColor where
-  defaultValue = Auto
-  parseValue = parseUseColor
-  optionName = return "color"
-  optionHelp = return "When to use colored output. Options are 'never', 'always' and 'auto' (default: 'auto')"
+  defaultValue   = Auto
+  parseValue     = parseUseColor
+  optionName     = return "color"
+  optionHelp     = return "When to use colored output. Options are 'never', 'always' and 'auto' (default: 'auto')"
   optionCLParser =
     option parse
       (  long name

--- a/Test/Tasty/Silver/Interactive.hs
+++ b/Test/Tasty/Silver/Interactive.hs
@@ -159,7 +159,7 @@ runSingleTest _ _ _ opts t cb = do
             GREqual -> return r
             grd -> return $ r { resultOutcome = (Failure $ TestThrewException $ toException $ Mismatch grd) }
 
--- | A simple console UI
+-- | A simple console UI.
 runTestsInteractive :: DisabledTests -> OptionSet -> TestTree -> IO Bool
 runTestsInteractive dis opts tests = do
   let tests' = wrapRunTest (runSingleTest dis) tests

--- a/Test/Tasty/Silver/Interactive.hs
+++ b/Test/Tasty/Silver/Interactive.hs
@@ -80,23 +80,28 @@ type DisabledTests = TestPath -> Bool
 
 -- | Like @defaultMain@ from the main tasty package, but also includes the
 -- golden test management capabilities.
+
 defaultMain :: TestTree -> IO ()
 defaultMain = defaultMain1 []
 
 
-defaultMain1 :: ([RegexFilter]) -> TestTree -> IO ()
-defaultMain1 filters = defaultMainWithIngredients
+defaultMain1 :: [RegexFilter] -> TestTree -> IO ()
+defaultMain1 filters =
+    defaultMainWithIngredients
         [ listingTests
         , interactiveTests (checkRF False filters)
         ]
 
+-- | Option for interactive mode.
+
 newtype Interactive = Interactive Bool
   deriving (Eq, Ord, Typeable)
+
 instance IsOption Interactive where
-  defaultValue = Interactive False
-  parseValue = fmap Interactive . safeRead
-  optionName = return "interactive"
-  optionHelp = return "Run tests in interactive mode."
+  defaultValue   = Interactive False
+  parseValue     = fmap Interactive . safeRead
+  optionName     = return "interactive"
+  optionHelp     = return "Run tests in interactive mode."
   optionCLParser = flagCLParser (Just 'i') (Interactive True)
 
 data ResultType = RTSuccess | RTFail | RTIgnore

--- a/Test/Tasty/Silver/Interactive/Run.hs
+++ b/Test/Tasty/Silver/Interactive/Run.hs
@@ -7,12 +7,14 @@ module Test.Tasty.Silver.Interactive.Run
   )
   where
 
-import Test.Tasty hiding (defaultMain)
-import Test.Tasty.Runners
-import Test.Tasty.Options
-import Data.Typeable
 import Data.Tagged
+import Data.Typeable
+
+import Test.Tasty hiding (defaultMain)
+import Test.Tasty.Options
 import Test.Tasty.Providers
+import Test.Tasty.Runners
+import Test.Tasty.Silver.Filter ( TestPath )
 
 data CustomTestExec t = IsTest t => CustomTestExec t (OptionSet -> t -> (Progress -> IO ()) -> IO Result)
   deriving (Typeable)
@@ -21,10 +23,9 @@ instance IsTest t => IsTest (CustomTestExec t) where
   run opts (CustomTestExec t r) cb = r opts t cb
   testOptions = retag $ (testOptions :: Tagged t [OptionDescription])
 
-type TestPath = String
-
 -- | Provide new test run function wrapping the existing tests.
-wrapRunTest :: (forall t . IsTest t => TestPath -> TestName -> OptionSet -> t -> (Progress -> IO ()) -> IO Result)
+wrapRunTest
+    :: (forall t . IsTest t => TestPath -> TestName -> OptionSet -> t -> (Progress -> IO ()) -> IO Result)
     -> TestTree
     -> TestTree
 wrapRunTest = wrapRunTest' "/"

--- a/Test/Tasty/Silver/Internal.hs
+++ b/Test/Tasty/Silver/Internal.hs
@@ -155,3 +155,13 @@ and2M ma mb = ifM ma mb $ return False
 
 andM :: Monad m => [m Bool] -> m Bool
 andM = Prelude.foldl and2M (return True)
+
+-- | Short-cutting version of @'liftM2' (||)@.
+
+or2M :: Monad m => m Bool -> m Bool -> m Bool
+or2M ma mb = ifM ma (return True) mb
+
+-- | Short-cutting version of @'or' . 'sequence'@.
+
+orM :: Monad m => [m Bool] -> m Bool
+orM = Prelude.foldl or2M (return False)

--- a/Test/Tasty/Silver/Internal.hs
+++ b/Test/Tasty/Silver/Internal.hs
@@ -24,7 +24,7 @@ import System.IO.Error
 import Test.Tasty.Providers
 import Test.Tasty.Options
 
--- | See 'goldenTest1' for explanation of the fields.
+-- | See 'Test.Tasty.Silver.Advanced.goldenTest1' for explanation of the fields.
 
 data Golden =
   forall a .
@@ -49,7 +49,7 @@ instance IsOption AcceptTests where
   optionHelp = return "Accept current results of golden tests"
   optionCLParser =  flagCLParser Nothing (AcceptTests True)
 
--- | Read the file if it exists, else return Nothing.
+-- | Read the file if it exists, else return 'Nothing'.
 -- Useful for reading golden files.
 
 readFileMaybe :: FilePath -> IO (Maybe SB.ByteString)

--- a/Test/Tasty/Silver/Internal.hs
+++ b/Test/Tasty/Silver/Internal.hs
@@ -130,3 +130,28 @@ instance Show (GoldenResult' m) where
   show GREqual = "GREqual"
   show (GRDifferent {}) = "GRDifferent"
   show (GRNoGolden {}) = "GRNoGolden"
+
+
+-- * Generic utilites
+
+-- | Monadic @if@.
+
+ifM :: Monad m => m Bool -> m a -> m a -> m a
+ifM mc mt me = do
+  c <- mc
+  if c then mt else me
+
+-- | Monadic @if (not ...) ...@.
+
+ifNotM :: Monad m => m Bool -> m a -> m a -> m a
+ifNotM mc = flip $ ifM mc
+
+-- | Short-cutting version of @'liftM2' (&&)@.
+
+and2M :: Monad m => m Bool -> m Bool -> m Bool
+and2M ma mb = ifM ma mb $ return False
+
+-- | Short-cutting version of @'and' . 'sequence'@.
+
+andM :: Monad m => [m Bool] -> m Bool
+andM = Prelude.foldl and2M (return True)

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,1 +1,1 @@
-installed: +all -bytestring -process
+installed: +all -bytestring -directory -process

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,1 +1,5 @@
 installed: +all -bytestring -directory -process
+
+-- on Linux we can use ghcup to setup (some) of jobs
+-- hvr-ppa latest are 9.0.1 and 8.10.4
+ghcup-jobs: >= 9.2 || > 8.10.4 && < 9.0

--- a/tasty-silver.cabal
+++ b/tasty-silver.cabal
@@ -69,7 +69,8 @@ library
       -- regex-tdfa has this lower bound on base, so we make it explicit here
     bytestring >= 0.9.2.1,
     containers,
-    directory >= 1.2.2,
+    directory >= 1.2.3.0,
+      -- withCurrentDirectory needs >= 1.2.3.0
       -- Andreas Abel, 2021-09-06, with 1.2.1.0 (GHC 7.8) it finds
       -- /usr/bin/git over the git in the PATH, crashing on macOS due to
       -- the system integrity restrictions:
@@ -110,6 +111,8 @@ Test-suite test
         -- Andreas Abel, 2021-09-05, latest silently is today 1.2.5.1
     , temporary
     , transformers >= 0.3
+  if impl(ghc < 8.0)
+    build-depends: semigroups
 
   if impl(ghc >= 8.0)
     ghc-options:

--- a/tasty-silver.cabal
+++ b/tasty-silver.cabal
@@ -69,7 +69,11 @@ library
       -- regex-tdfa has this lower bound on base, so we make it explicit here
     bytestring >= 0.9.2.1,
     containers,
-    directory,
+    directory >= 1.2.2,
+      -- Andreas Abel, 2021-09-06, with 1.2.1.0 (GHC 7.8) it finds
+      -- /usr/bin/git over the git in the PATH, crashing on macOS due to
+      -- the system integrity restrictions:
+      -- /usr/bin/git: fileAccess: permission denied (Operation not permitted)
     deepseq,
     filepath,
     mtl,

--- a/tasty-silver.cabal
+++ b/tasty-silver.cabal
@@ -1,5 +1,5 @@
 name:                tasty-silver
-version:             3.2.3
+version:             3.3
 synopsis:            A fancy test runner, including support for golden tests.
 description:
   This package provides a fancy test runner and support for «golden testing».
@@ -29,8 +29,9 @@ extra-source-files:
   README.md
 
 tested-with:
+  GHC == 9.2.0.20210821
   GHC == 9.0.1
-  GHC == 8.10.4
+  GHC == 8.10.7
   GHC == 8.8.4
   GHC == 8.6.5
   GHC == 8.4.4

--- a/tasty-silver.cabal
+++ b/tasty-silver.cabal
@@ -65,24 +65,20 @@ library
 
   build-depends:
     base >= 4.5
-      -- regex-tdfa has this lower bound on base, so we make it explicit here
+        -- regex-tdfa has this lower bound on base, so we make it explicit here
     , ansi-terminal >= 0.6.2.1
     , async
     , bytestring >= 0.9.2.1
     , containers
     , directory >= 1.2.3.0
-      -- withCurrentDirectory needs >= 1.2.3.0
-      -- Andreas Abel, 2021-09-06, with 1.2.1.0 (GHC 7.8) it finds
-      -- /usr/bin/git over the git in the PATH, crashing on macOS due to
-      -- the system integrity restrictions:
-      -- /usr/bin/git: fileAccess: permission denied (Operation not permitted)
+        -- withCurrentDirectory needs >= 1.2.3.0
     , deepseq
     , filepath
     , mtl
     , optparse-applicative
     , process >= 1.2
     , process-extras >= 0.3
-      -- readCreateProcessWithExitCode needs >= 0.3
+        -- readCreateProcessWithExitCode needs >= 0.3
     , regex-tdfa >= 1.2.0
     , silently >= 1.2.5.1
         -- Andreas Abel, 2021-09-05, latest silently is today 1.2.5.1

--- a/tasty-silver.cabal
+++ b/tasty-silver.cabal
@@ -63,31 +63,33 @@ library
       -Wcompat
 
   build-depends:
-    ansi-terminal >= 0.6.2.1,
-    async,
-    base >= 4.5,
+    base >= 4.5
       -- regex-tdfa has this lower bound on base, so we make it explicit here
-    bytestring >= 0.9.2.1,
-    containers,
-    directory >= 1.2.3.0,
+    , ansi-terminal >= 0.6.2.1
+    , async
+    , bytestring >= 0.9.2.1
+    , containers
+    , directory >= 1.2.3.0
       -- withCurrentDirectory needs >= 1.2.3.0
       -- Andreas Abel, 2021-09-06, with 1.2.1.0 (GHC 7.8) it finds
       -- /usr/bin/git over the git in the PATH, crashing on macOS due to
       -- the system integrity restrictions:
       -- /usr/bin/git: fileAccess: permission denied (Operation not permitted)
-    deepseq,
-    filepath,
-    mtl,
-    optparse-applicative,
-    process >= 1.2,
-    process-extras >= 0.3,
+    , deepseq
+    , filepath
+    , mtl
+    , optparse-applicative
+    , process >= 1.2
+    , process-extras >= 0.3
       -- readCreateProcessWithExitCode needs >= 0.3
-    regex-tdfa >= 1.2.0,
-    stm >= 2.4.2,
-    tagged,
-    tasty >= 1.4,
-    temporary,
-    text >= 0.11.0.0
+    , regex-tdfa >= 1.2.0
+    , silently >= 1.2.5.1
+        -- Andreas Abel, 2021-09-05, latest silently is today 1.2.5.1
+    , stm >= 2.4.2
+    , tagged
+    , tasty >= 1.4
+    , temporary
+    , text >= 0.11.0.0
   if impl(ghc < 8.0)
     build-depends: semigroups >= 0.18.3
 

--- a/tasty-silver.cabal
+++ b/tasty-silver.cabal
@@ -3,14 +3,14 @@ version:             3.3
 synopsis:            A fancy test runner, including support for golden tests.
 description:
   This package provides a fancy test runner and support for «golden testing».
-
+  .
   A golden test is an IO action that writes its result to a file.
   To pass the test, this output file should be identical to the corresponding
   «golden» file, which contains the correct result for the test.
-
+  .
   The test runner allows filtering tests using regexes, and to interactively
   inspect the result of golden tests.
-
+  .
   This package is a heavily extended fork of tasty-golden.
 
 license:             MIT

--- a/tasty-silver.cabal
+++ b/tasty-silver.cabal
@@ -80,7 +80,8 @@ library
     mtl,
     optparse-applicative,
     process >= 1.2,
-    process-extras >= 0.2,
+    process-extras >= 0.3,
+      -- readCreateProcessWithExitCode needs >= 0.3
     regex-tdfa >= 1.2.0,
     stm >= 2.4.2,
     tagged,

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -38,7 +38,9 @@ main = defaultMain $ testGroup "tests" $
   testFindByExt :
   testWithResource :
   testCheckRF :
-  testGolden :
+  -- Andreas, 2021-09-18
+  -- @testGolden@ always fails, would need @--accept@ mode.
+  -- testGolden :
   []
 
 testFindByExt :: TestTree
@@ -89,15 +91,16 @@ testShowDiff =
           putStr out
           assertBool "Test should succeed." success
 
-testGolden :: TestTree
-testGolden =
-  goldenTest1
-    "wrongOutput"
-    (return $ Just "golden value")
-    (return "actual value")
-    (DiffText Nothing)   -- always fail
-    ShowText
-    (const $ return ())  -- keep the golden file no matter what
+-- UNUSED, but KEEP!
+-- testGolden :: TestTree
+-- testGolden =
+--   goldenTest1
+--     "wrongOutput"
+--     (return $ Just "golden value")
+--     (return "actual value")
+--     (DiffText Nothing)   -- always fail
+--     ShowText
+--     (const $ return ())  -- keep the golden file no matter what
 
 -- | Check if resources are properly initialized.
 testWithResource :: TestTree

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 import Control.Concurrent.MVar
-import Control.Exception      ( catch, IOException, SomeException )
+import Control.Exception as E ( catch, IOException, SomeException )
+  -- Prelude of GHC 7.4 also has @catch@, so we disambiguate with E.catch
 import Control.Monad          ( unless )
 import Control.Monad.IO.Class ( liftIO )
 import Data.List (sort)
@@ -78,7 +79,7 @@ testShowDiff =
       do
           -- let io = defaultMain tree
           let io = runTestsInteractive (const False) mempty tree
-          (out, success) <- capture $ catch (True <$ io) $ \ (e :: SomeException) -> do
+          (out, success) <- capture $ E.catch (True <$ io) $ \ (e :: SomeException) -> do
              print e
              return False
           -- unless success $ putStr out

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -12,7 +12,7 @@ import Data.Functor           ( (<$) )
 import Data.Monoid            ( mempty )
 #endif
 
-import System.Directory
+import System.Directory       ( createDirectory, withCurrentDirectory )
 import System.FilePath
 import System.IO.Silently     ( capture )
 import System.IO.Temp
@@ -42,8 +42,8 @@ testFindByExt :: TestTree
 testFindByExt =
   testCase "findByExtension" $
     withSystemTempDirectory "golden-test" $ \basedir -> do
-
-      setCurrentDirectory basedir
+     withCurrentDirectory basedir $ do
+      -- Andreas 2021-09-07: setCurrentDirectory would affect other tests!
 
       createDirectory ("d1")
       createDirectory ("d1" </> "d2")

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 import Control.Concurrent.MVar
-import Control.Exception as E ( catch, IOException, SomeException )
+import Control.Exception as E ( catch, SomeException )
   -- Prelude of GHC 7.4 also has @catch@, so we disambiguate with E.catch
 import Control.Monad          ( unless )
 import Control.Monad.IO.Class ( liftIO )

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -75,9 +75,9 @@ testShowDiff =
                         writeFile actualFile actualValue
       writeFile goldenFile goldenValue
       writeFile actualFile actualValue
-      case tryIngredients [consoleTestReporter] mempty tree of
-        Nothing -> assertFailure "Testbroken"  -- should be impossible
-        Just io -> do
+      do
+          let io = defaultMain tree
+          -- let io = runTestsInteractive (const False) mempty tree
           (out, success) <- capture $ catch (True <$ io) $ \ (e :: IOException) -> do
              print e
              return False

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 import Control.Concurrent.MVar
-import Control.Exception      ( catch, IOException )
+import Control.Exception      ( catch, IOException, SomeException )
 import Control.Monad          ( unless )
 import Control.Monad.IO.Class ( liftIO )
 import Data.List (sort)
@@ -71,17 +71,18 @@ testShowDiff =
         goldenValue = "golden value"
         actualFile  = dir </> "actual.txt"
         actualValue = "actual value"
-        tree        = goldenVsFile "showDiff" goldenFile actualFile $
+        tree        = goldenVsFile "showDiff-internal" goldenFile actualFile $
                         writeFile actualFile actualValue
       writeFile goldenFile goldenValue
       writeFile actualFile actualValue
       do
-          let io = defaultMain tree
-          -- let io = runTestsInteractive (const False) mempty tree
-          (out, success) <- capture $ catch (True <$ io) $ \ (e :: IOException) -> do
+          -- let io = defaultMain tree
+          let io = runTestsInteractive (const False) mempty tree
+          (out, success) <- capture $ catch (True <$ io) $ \ (e :: SomeException) -> do
              print e
              return False
-          unless success $ putStr out
+          -- unless success $ putStr out
+          putStr out
           assertBool "Test should succeed." success
 
 -- | Check if resources are properly initialized.

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 import Control.Concurrent.MVar
@@ -6,6 +7,7 @@ import Control.Exception as E ( catch, IOException, SomeException )
   -- Prelude of GHC 7.4 also has @catch@, so we disambiguate with E.catch
 import Control.Monad          ( unless )
 import Control.Monad.IO.Class ( liftIO )
+
 import Data.List (sort)
 #if !(MIN_VERSION_base(4,8,0))
 import Data.Functor           ( (<$) )
@@ -36,6 +38,7 @@ main = defaultMain $ testGroup "tests" $
   testFindByExt :
   testWithResource :
   testCheckRF :
+  testGolden :
   []
 
 testFindByExt :: TestTree
@@ -85,6 +88,16 @@ testShowDiff =
           -- unless success $ putStr out
           putStr out
           assertBool "Test should succeed." success
+
+testGolden :: TestTree
+testGolden =
+  goldenTest1
+    "wrongOutput"
+    (return $ Just "golden value")
+    (return "actual value")
+    (DiffText Nothing)   -- always fail
+    ShowText
+    (const $ return ())  -- keep the golden file no matter what
 
 -- | Check if resources are properly initialized.
 testWithResource :: TestTree


### PR DESCRIPTION
Windows portability (fix #16).

See README and CHANGELOG for a high-level description of changes.

I am planning to release this as 3.3 (major version), since the logic of interactive running without `stdin` has changes (assumes "yes" now).