### PR TITLE
v3.3.1.3: fix regression with tasty-1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 Changes
 =======
 
-Unreleased
-----------
+Version 3.3.1.3 (20 Oct 2023)
+---------------
 
+_Dedicated to Anne-Christine. Happy birthday!_
+
+* Fix test reporting when built with `tasty-1.5`
+  (regression in 3.3.1.2, see [#41](https://github.com/phile314/tasty-silver/issues/41)).
 * `filterWithRedex` is now the identity if no inclusion/exclusion regexes are given in the options.
-* Drop support for GHC 7.4
+* Drop support for GHC 7.4 for the sake of `LambdaCase`.
+* Tested with GHC 8.0 - 9.8.1.
 
 Version 3.3.1.2 (10 Sep 2023)
 ---------------

--- a/Test/Tasty/Silver/Interactive.hs
+++ b/Test/Tasty/Silver/Interactive.hs
@@ -565,12 +565,12 @@ produceOutput opts tree =
       let handleTestResult' = (if isInteractive then handleTestResultInteractive else handleTestResult)
       return $ HandleTest name printTestName handleTestResult'
 
-    handleGroup :: OptionSet -> TestName -> Ap (Reader Level) TestOutput -> Ap (Reader Level) TestOutput
+    handleGroup :: OptionSet -> TestName -> [Ap (Reader Level) TestOutput] -> Ap (Reader Level) TestOutput
     handleGroup _ name grp = Ap $ do
       level <- ask
       let
         printHeading = printf "%s%s\n" (indent level) name
-        printBody = runReader (getApp grp) (level + 1)
+        printBody = runReader (getApp $ mconcat grp) (level + 1)
       return $ PrintHeading printHeading printBody
 
   in
@@ -579,9 +579,9 @@ produceOutput opts tree =
         trivialFold
           { foldSingle = handleSingleTest
 #if MIN_VERSION_tasty(1,5,0)
-          , foldGroup = \ opts name -> foldMap (handleGroup opts name)
+          , foldGroup = \ opts name ts -> handleGroup opts name ts
 #else
-          , foldGroup = \ opts name -> id      (handleGroup opts name)
+          , foldGroup = \ opts name t  -> handleGroup opts name [t]
 #endif
           }
           opts tree

--- a/tasty-silver.cabal
+++ b/tasty-silver.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.14
 name:                tasty-silver
-version:             3.3.1.2
+version:             3.3.1.3
 synopsis:            A fancy test runner, including support for golden tests.
 description:
   This package provides a fancy test runner and support for «golden testing».


### PR DESCRIPTION
The port to `tasty-1.5` was changing the console reporting as described in:
- #41

Closes #41
