### PR TITLE
Release 3.3.2.1

### DIFF
--- a/.github/workflows/cabal-mac-win.yml
+++ b/.github/workflows/cabal-mac-win.yml
@@ -30,7 +30,7 @@ jobs:
       matrix: { os: [macos-latest, ubuntu-latest, windows-latest] }
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
 

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250506
+# version: 0.19.20250821
 #
-# REGENDATA ("0.19.20250506",["github","tasty-silver.cabal"])
+# REGENDATA ("0.19.20250821",["github","tasty-silver.cabal"])
 #
 name: Haskell-CI
 on:
@@ -32,6 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.0.20250819
+            compilerKind: ghc
+            compilerVersion: 9.14.0.20250819
+            setup-method: ghcup-prerelease
+            allow-failure: false
           - compiler: ghc-9.12.2
             compilerKind: ghc
             compilerVersion: 9.12.2
@@ -110,11 +115,26 @@ jobs:
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+        env:
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
+      - name: Install GHC (GHCup prerelease)
+        if: matrix.setup-method == 'ghcup-prerelease'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel prereleases
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
           HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
@@ -136,7 +156,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -164,6 +184,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -212,9 +244,16 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_tasty_silver}" >> cabal.project
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package tasty-silver" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package tasty-silver" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package tasty-silver" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(tasty-silver)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 Changes
 =======
 
-* Drop support for GHC 7.
+Version 3.3.2.1 (31 Aug 2025)
+---------------
 
+* Drop support for GHC 7.
+* Rudimentary treatment for `After` in `TestTree`
+  (cf. [#28](https://github.com/phile314/tasty-silver/issues/28)).
 * Tested with GHC 8.0 - 9.12.2.
 
 Version 3.3.2 (18 Jul 2024)

--- a/Test/Tasty/Silver/Filter.hs
+++ b/Test/Tasty/Silver/Filter.hs
@@ -29,7 +29,7 @@ import qualified Text.Regex.TDFA as R
 
 import Test.Tasty         ( TestTree, testGroup )
 import Test.Tasty.Options ( IsOption(..), OptionSet, lookupOption )
-import Test.Tasty.Runners ( TestTree(AskOptions, SingleTest, TestGroup, PlusTestOptions, WithResource) )
+import Test.Tasty.Runners ( TestTree(After, AskOptions, SingleTest, TestGroup, PlusTestOptions, WithResource) )
 
 -- | Path into the 'TestTree'.  Separator is the slash character(@'/'@).
 type TestPath = String
@@ -127,6 +127,9 @@ filterWithPred f tree = fromMaybe emptyTest $ filter' "/" tree
       -- if later on we see that the child subtree was excluded.
       WithResource r t    -> Just $ WithResource r $ \ x -> fromMaybe emptyTest $ filter' path $ t x
       AskOptions t        -> Just $ AskOptions     $ \ o -> fromMaybe emptyTest $ filter' path $ t o
+#if MIN_VERSION_tasty(1,2,0)
+      After dep exp t     -> After dep exp <$> filter' path t
+#endif
 
     x <//> y = x ++ "/" ++ y
 

--- a/Test/Tasty/Silver/Interactive/Run.hs
+++ b/Test/Tasty/Silver/Interactive/Run.hs
@@ -28,11 +28,13 @@ wrapRunTest' :: TestPath
     -> (forall t . IsTest t => TestPath -> TestName -> OptionSet -> t -> (Progress -> IO ()) -> IO Result)
     -> TestTree
     -> TestTree
-wrapRunTest' tp f (SingleTest n t) = SingleTest n (CustomTestExec t (f (tp <//> n) n))
-wrapRunTest' tp f (TestGroup n ts) = TestGroup n (fmap (wrapRunTest' (tp <//> n) f) ts)
-wrapRunTest' tp f (PlusTestOptions o t) = PlusTestOptions o (wrapRunTest' tp f t)
-wrapRunTest' tp f (WithResource r t) = WithResource r (\x -> wrapRunTest' tp f (t x))
-wrapRunTest' tp f (AskOptions t) = AskOptions (\o -> wrapRunTest' tp f (t o))
+wrapRunTest' tp f = \case
+  SingleTest n t      -> SingleTest n (CustomTestExec t (f (tp <//> n) n))
+  TestGroup n ts      -> TestGroup n (fmap (wrapRunTest' (tp <//> n) f) ts)
+  PlusTestOptions o t -> PlusTestOptions o (wrapRunTest' tp f t)
+  WithResource r t    -> WithResource r (\x -> wrapRunTest' tp f (t x))
+  AskOptions t        -> AskOptions (\o -> wrapRunTest' tp f (t o))
+  After dep expr t    -> After dep expr $ wrapRunTest' tp f t
 
 (<//>) :: TestPath -> TestPath -> TestPath
 a <//> b = a ++ "/" ++ b

--- a/tasty-silver.cabal
+++ b/tasty-silver.cabal
@@ -1,6 +1,6 @@
-cabal-version:       1.14
+cabal-version:       1.18
 name:                tasty-silver
-version:             3.3.2
+version:             3.3.2.1
 synopsis:            A fancy test runner, including support for golden tests.
 description:
   This package provides a fancy test runner and support for «golden testing».
@@ -20,11 +20,10 @@ Homepage:            https://github.com/phile314/tasty-silver
 Bug-reports:         https://github.com/phile314/tasty-silver/issues
 author:              Philipp Hausmann, Andreas Abel, Roman Cheplyaka, and others
 maintainer:          Andreas Abel, Philipp Hausmann
--- copyright:
 category:            Testing
 build-type:          Simple
 
-extra-source-files:
+extra-doc-files:
   CHANGELOG.md
   README.md
 
@@ -57,29 +56,28 @@ library
     Test.Tasty.Silver.Interactive.Run
     Test.Tasty.Silver.Internal
 
+  -- Lower bounds taken from GHC 8.0 and Stackage LTS 7.0
   build-depends:
-      base           >= 4.9 && < 5
+      base                  >= 4.9 && < 5
         -- Drop support for GHC 7
-    , ansi-terminal  >= 0.6.2.1
-    , bytestring     >= 0.10.0.0
-        -- bytestring-0.10 needed by process-extras-0.3
-    , containers
-    , directory      >= 1.2.3.0
-        -- withCurrentDirectory needs at least 1.2.3.0
-    , filepath
-    , mtl
-    , optparse-applicative
-    , process        >= 1.2
-    , process-extras >= 0.3
-        -- readCreateProcessWithExitCode needs at least 0.3
-    , regex-tdfa     >= 1.2.0
-    , silently       >= 1.2.5.1
-        -- Andreas Abel, 2021-09-05, latest silently is today 1.2.5.1
-    , stm            >= 2.4.2
-    , tagged
-    , tasty          >= 1.4
-    , temporary
-    , text           >= 0.11.0.0
+    , ansi-terminal         >= 0.6.2.3
+    , bytestring            >= 0.10.8.0
+    , containers            >= 0.5.7.1
+    , directory             >= 1.2.6.2
+    , filepath              >= 1.4.1.0
+    , mtl                   >= 2.2.1
+    , optparse-applicative  >= 0.12.1.0
+    , process               >= 1.4.2.0
+    , process-extras        >= 0.4.1.4
+    , regex-tdfa            >= 1.2.2
+    , silently              >= 1.2.5.1
+        -- 1.2.5.1 contains a bugfix (Windows NUL device) over 1.2.5
+    , stm                   >= 2.4.4.1
+    , tagged                >= 0.8.5
+    , tasty                 >= 1.4
+        -- LTS 7.0 contains a much older tasty: 0.11.0.4
+    , temporary             >= 1.2.0.4
+    , text                  >= 1.2.2.1
 
   default-language:
     Haskell2010
@@ -124,10 +122,8 @@ Test-suite test
     , tasty-silver
     , filepath
     , directory
-    , process
     , silently
     , temporary
-    , transformers
 
   ghc-options:
     -Wall

--- a/tasty-silver.cabal
+++ b/tasty-silver.cabal
@@ -29,6 +29,7 @@ extra-source-files:
   README.md
 
 tested-with:
+  GHC == 9.14.1
   GHC == 9.12.2
   GHC == 9.10.2
   GHC == 9.8.4
@@ -60,13 +61,11 @@ library
       base           >= 4.9 && < 5
         -- Drop support for GHC 7
     , ansi-terminal  >= 0.6.2.1
-    , async
     , bytestring     >= 0.10.0.0
         -- bytestring-0.10 needed by process-extras-0.3
     , containers
     , directory      >= 1.2.3.0
         -- withCurrentDirectory needs at least 1.2.3.0
-    , deepseq
     , filepath
     , mtl
     , optparse-applicative
@@ -81,7 +80,6 @@ library
     , tasty          >= 1.4
     , temporary
     , text           >= 0.11.0.0
-    , transformers   >= 0.3
 
   default-language:
     Haskell2010
@@ -106,6 +104,9 @@ library
     -Wall
     -Wno-name-shadowing
     -Wcompat
+    -Wunused-packages
+    -Wincomplete-patterns
+    -Wincomplete-uni-patterns
 
 Test-suite test
   Default-language:


### PR DESCRIPTION
- **Bump Haskell CI to GHC 9.14 alpha1**
  

- **Bump version to 3.3.2.1 and CHANGELOG; bump lower bounds to LTS 7.0**

Candidate: https://hackage.haskell.org/package/tasty-silver-3.3.2.1/candidate
  